### PR TITLE
Bug report: citeproc-js renders all (non-empty) cs:substitute children

### DIFF
--- a/processor-tests/humans/bugreports_SubstituteOnlyOnce.txt
+++ b/processor-tests/humans/bugreports_SubstituteOnlyOnce.txt
@@ -1,0 +1,43 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+
+>>===== RESULT =====>>
+a
+<<===== RESULT =====<<
+
+
+>>===== CSL =====>>
+<style 
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2019-08-11T16:56:00+02:00</updated>
+  </info>
+  <citation>
+    <layout>
+      <names>
+        <substitute>
+          <text value="a"/>
+          <text value="b"/>
+        </substitute>
+      </names>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "id": "ITEM-1",
+        "type": "book"
+    }
+]
+<<===== INPUT =====<<


### PR DESCRIPTION
Current behaviour: https://runkit.com/larsgw/citeproc-js-rendering-all-cs-substitute-children

> If `cs:substitute` contains multiple child elements, the **first element** to return a non-empty result is used for substitution.