### PR TITLE
Regex in processor.py too greedy

### DIFF
--- a/processor.py
+++ b/processor.py
@@ -226,7 +226,7 @@ class CslTest:
         self.hp = os.path.sep.join( hpath )
         self.CREATORS = ["author","editor","translator","recipient","interviewer"]
         self.CREATORS += ["composer","original-author","container-author","collection-editor"]
-        self.RE_ELEMENT = '(?sm)^(.*>>=.*%s[^\n]+)(.*)(\n<<=.*%s.*)'
+        self.RE_ELEMENT = '(?sm)^(.*>>=[^\n]*%s[^\n]+)(.*)(\n<<=.*%s.*)'
         self.RE_FILENAME = '^[a-z]+_[a-zA-Z0-9]+\.txt$'
         self.script = os.path.split(sys.argv[0])[1]
         self.pickle = ".".join((os.path.splitext( self.script )[0], "pkl"))


### PR DESCRIPTION
When converting human-readable test code into machine-readable form, processor.py uses a regex to extract individual elements. This regex is too greedy.

For example, the test https://github.com/citation-style-language/test-suite/blob/master/processor-tests/humans/bugreports_EnvAndUrb.txt contains a CSL style in XML form. The XML document contains the string `CSL` (in the `<summary>` node). The regex thinks the element delimiter goes from `>>=` to the last occurrence of `CSL` including the rest of the line. It extracts invalid XML code starting with `<updated>` instead of `<?xml...`.

In consequence, citeproc-js is not able to parse the XML and crashes with an error saying that the `push` function does not exist on `undefined`.

This commit fixes the problem. Instead of looking for `>>=.*CSL` (which includes line breaks), it looks for `>>=[^\n]*CSL`.

Note that the old `test.py` from https://github.com/Juris-M/citeproc-js already contained this fix. The regex there was even more complex:

https://github.com/Juris-M/citeproc-js/blob/9c0f42639128bae25307f248669c827ed32adcd3/test.py#L437

But I'm not sure if this complexity is necessary here. I ran the test suite with the fix and was able to correctly convert all test files.

Note that this fix applies to the following test files:
* https://github.com/citation-style-language/test-suite/blob/master/processor-tests/humans/bugreports_EnvAndUrb.txt
* https://github.com/citation-style-language/test-suite/blob/master/processor-tests/humans/group_LegalWithAuthorDate
* https://github.com/citation-style-language/test-suite/blob/master/processor-tests/humans/name_BibliographyNameFormNeverShrinks
* https://github.com/citation-style-language/test-suite/blob/master/processor-tests/humans/bugreports_DelimiterOnLayout

All of them have the string `CSL` somewhere in the XML document.