### PR TITLE
Add ignore.txt list to test suite

### DIFF
--- a/processor-tests/humans/ignore.txt
+++ b/processor-tests/humans/ignore.txt
@@ -1,0 +1,52 @@
+# vim: set ft=sh :
+# that's for comments
+
+# This is borrowed from https://github.com/cormacrelf/citeproc-rs/blob/cd73f28945a980e984e73163f6f59e513336c570/crates/citeproc/tests/data/ignore.txt
+# It lists the test in this directory one should likely ignore for now, with
+# explanation.
+
+# relies on the "near-note": true, or "position": INTEGER, forcing options in
+# citeproc-js, # whereas in citeproc-rs cite positions only work automatically.
+position_NearNoteTrue.txt
+nameattr_EtAlSubsequentMinOnCitationInCitation.txt
+nameattr_EtAlSubsequentMinOnStyleInCitation.txt
+nameattr_EtAlSubsequentUseFirstOnCitationInCitation.txt
+nameattr_EtAlSubsequentUseFirstOnStyleInCitation.txt
+
+# these also use that, but the cites / clusters are in the correct order such that
+# the forcing options reflect the actual positions.
+# disambiguate_BasedOnSubsequentFormWithBackref.txt
+# disambiguate_BasedOnSubsequentFormWithLocator.txt
+
+# uses a whole lot of citeproc-js options
+form_ShortTitleOnly.txt
+
+# better to reject this kind of thing, isn't it?
+bugreports_EmptyInput.txt
+
+# note field parsing should be done higher up
+bugreports_IllustratorInExtra.txt
+
+# ABBREVIATIONS not implemented or part of CSL
+bugreports_TwoFullStops.txt
+variables_TitleShortOnAbbrevWithTitleGroup.txt
+variables_TitleShortOnAbbrevWithTitleCondition.txt
+number_EditionSort.txt
+variables_TitleShortOnAbbrevWithTitle.txt
+variables_ShortForm.txt
+
+# citeproc-js feature
+sort_CitationUnsorted.txt
+
+# BIBENTRIES
+api_UpdateItemsDeleteDecrementsByCiteDisambiguation.txt
+sort_CitationEdit.txt
+api_UpdateItemsReshuffle.txt
+api_UpdateItemsDelete.txt
+
+# bibliography-header mode
+bibheader_EntryspacingDefaultValueOne.txt
+bibheader_EntryspacingExplicitValueZero.txt
+bibheader_SecondFieldAlign.txt
+bibheader_SecondFieldAlignWithAuthor.txt
+bibheader_SecondFieldAlignWithNumber.txt

--- a/processor-tests/humans/ignore.txt
+++ b/processor-tests/humans/ignore.txt
@@ -50,3 +50,8 @@ bibheader_EntryspacingExplicitValueZero.txt
 bibheader_SecondFieldAlign.txt
 bibheader_SecondFieldAlignWithAuthor.txt
 bibheader_SecondFieldAlignWithNumber.txt
+
+# citation-rtf mode 
+bugreports_NonBreakingSpaceJoinFail.txt
+# bibliography-nosort mode
+sort_BibliographyNosortOption.txt


### PR DESCRIPTION
Until #17 is addressed, this borrows the ignore.txt list from the
citeproc-rs project, with explanation, to provide guidance to
implementers on which tests they should ignore.

The format of this file is designed for easy machine processing; 
just a single filename per line.

Items are on this list because they rely on undocumented modes 
specific to one implementation.