### PR TITLE
Remove variable call from macro

### DIFF
--- a/processor-tests/humans/sort_ConditionalMacroDates.txt
+++ b/processor-tests/humans/sort_ConditionalMacroDates.txt
@@ -25,7 +25,6 @@ bibliography
   </info>
   <macro name="issued-date">
     <group prefix="[" suffix="]">
-    <text variable="title"/>
     <choose>
       <if type="book">
         <date variable="issued">


### PR DESCRIPTION
I'm not really sure if this is right, but ...

Except in rare cases, macros that render more than one element should 
be avoided as sort keys, as they can lead to unexpected sorting in edge 
cases. Instead, use their elements as individual, consecutive sort keys.

Closes #31