### PR TITLE
Add more description markers and links to test-relevant discussions

### DIFF
--- a/processor-tests/humans/bugreports_UndefinedInName3.txt
+++ b/processor-tests/humans/bugreports_UndefinedInName3.txt
@@ -2,6 +2,7 @@
 citation
 <<===== MODE =====<<
 
+>>===== DESCRIPTION =====>>
 Bug report by Carles Pina.
 
 ## 2013-04-17 :: Frank Bennett <biercenator@gmail.com>
@@ -11,6 +12,7 @@ Bug report by Carles Pina.
   specification was subsequently revised to required "by-cite"
   disambiguation. Under by-cite disambiguation, the subsequent form in
   the style is "Kim and Kim", without the given names.
+<<===== DESCRIPTION =====<<
 
 >>===== RESULT =====>>
 B-X Kim and A-Y Kim.

--- a/processor-tests/humans/date_SortEmptyDatesBibliography.txt
+++ b/processor-tests/humans/date_SortEmptyDatesBibliography.txt
@@ -4,10 +4,8 @@ bibliography
 
 
 >>===== DESCRIPTION =====>>
-Sort position of empty dates differs in citations and bibliographies.
-In citations, empty dates have a value equivalent to zero.  In
-bibliographies, they are always placed at the end of the sort
-(whether ascending or descending).
+Citation and bibliography items should both sort empty dates last. See discussion
+https://github.com/citation-style-language/test-suite/issues/70
 <<===== DESCRIPTION =====<<
 
 

--- a/processor-tests/humans/date_SortEmptyDatesCitation.txt
+++ b/processor-tests/humans/date_SortEmptyDatesCitation.txt
@@ -4,7 +4,8 @@ citation
 
 
 >>===== DESCRIPTION =====>>
-Citation and bibliography items should both sort empty dates last.
+Citation and bibliography items should both sort empty dates last. See discussion
+https://github.com/citation-style-language/test-suite/issues/70
 <<===== DESCRIPTION =====<<
 
 

--- a/processor-tests/humans/date_SortEmptyDatesCitation.txt
+++ b/processor-tests/humans/date_SortEmptyDatesCitation.txt
@@ -2,10 +2,14 @@
 citation
 <<===== MODE =====<<
 
+
+>>===== DESCRIPTION =====>>
 Sort position of empty dates differs in citations and bibliographies.
 In citations, empty dates have a value equivalent to zero.  In
 bibliographies, they are always placed at the end of the sort
 (whether ascending or descending).
+<<===== DESCRIPTION =====<<
+
 
 >>===== RESULT =====>>
 BookD 1999; BookB 2000; BookA; BookC; BookE.

--- a/processor-tests/humans/date_SortEmptyDatesCitation.txt
+++ b/processor-tests/humans/date_SortEmptyDatesCitation.txt
@@ -4,10 +4,7 @@ citation
 
 
 >>===== DESCRIPTION =====>>
-Sort position of empty dates differs in citations and bibliographies.
-In citations, empty dates have a value equivalent to zero.  In
-bibliographies, they are always placed at the end of the sort
-(whether ascending or descending).
+Citation and bibliography items should both sort empty dates last.
 <<===== DESCRIPTION =====<<
 
 

--- a/processor-tests/humans/fullstyles_APA.txt
+++ b/processor-tests/humans/fullstyles_APA.txt
@@ -2,12 +2,14 @@
 citation
 <<===== MODE =====<<
 
+>>===== DESCRIPTION =====>>
 This is correct APA ...
 
 See:
    http://forums.zotero.org/discussion/17859/style-error-for-apa-non-primary-author-initials-incorrectly-included/
 and followup thread:
    http://forums.zotero.org/discussion/19570/option-to-disable-disambiguation/
+<<===== DESCRIPTION =====<<
 
 >>===== RESULT =====>>
 (Oblinger &#38; Oblinger, 2009)

--- a/processor-tests/humans/number_PlainHyphenOrEnDashAlwaysPlural.txt
+++ b/processor-tests/humans/number_PlainHyphenOrEnDashAlwaysPlural.txt
@@ -6,6 +6,9 @@ citation
 >>===== DESCRIPTION =====>>
 Test to cover request here:
 http://xbiblio-devel.2463403.n2.nabble.com/contextual-labels-for-non-numeric-page-ranges-td7578166.html
+
+See also:
+https://discourse.citationstyles.org/t/contextual-labels-for-non-numeric-page-ranges/1117
 <<===== DESCRIPTION =====<<
 
 

--- a/processor-tests/humans/number_PlainHyphenOrEnDashAlwaysPlural.txt
+++ b/processor-tests/humans/number_PlainHyphenOrEnDashAlwaysPlural.txt
@@ -3,9 +3,10 @@ citation
 <<===== MODE =====<<
 
 
+>>===== DESCRIPTION =====>>
 Test to cover request here:
-
-  http://xbiblio-devel.2463403.n2.nabble.com/contextual-labels-for-non-numeric-page-ranges-td7578166.html
+http://xbiblio-devel.2463403.n2.nabble.com/contextual-labels-for-non-numeric-page-ranges-td7578166.html
+<<===== DESCRIPTION =====<<
 
 
 >>===== RESULT =====>>

--- a/processor-tests/humans/textcase_LocaleUnicode.txt
+++ b/processor-tests/humans/textcase_LocaleUnicode.txt
@@ -2,10 +2,10 @@
 citation
 <<===== MODE =====<<
 
+>>===== DESCRIPTION =====>>
 Details here:
-
 https://forums.zotero.org/discussion/83567/uppercase-letter-problem-in-turkish
-
+<<===== DESCRIPTION =====<<
 
 >>===== RESULT =====>>
 IA AND IB EN


### PR DESCRIPTION
This may seem a bit random 🙂 It’s just that I only need to open test files that don’t pass — those are the ones I update.

Notably, this updates a couple test descriptions per #70 