### PR TITLE
Update author label due to changes in locales

### DIFF
--- a/processor-tests/humans/name_EtAlWithCombined.txt
+++ b/processor-tests/humans/name_EtAlWithCombined.txt
@@ -8,7 +8,7 @@ bibliography
 >>===== RESULT =====>>
 <div class="csl-bib-body">
   <div class="csl-entry">John Doe。</div>
-  <div class="csl-entry">——著，Ziggy Zither等點校。</div>
+  <div class="csl-entry">——，Ziggy Zither等點校。</div>
   <div class="csl-entry">田中太郎, Yossarian Yoda, 等翻譯員。</div>
 </div>
 <<===== RESULT =====<<

--- a/processor-tests/machines/name_EtAlWithCombined.json
+++ b/processor-tests/machines/name_EtAlWithCombined.json
@@ -76,7 +76,7 @@
         }
     ],
     "mode": "bibliography",
-    "result": "<div class=\"csl-bib-body\">\n  <div class=\"csl-entry\">John Doe。</div>\n  <div class=\"csl-entry\">——著，Ziggy Zither等點校。</div>\n  <div class=\"csl-entry\">田中太郎, Yossarian Yoda, 等翻譯員。</div>\n</div>",
+    "result": "<div class=\"csl-bib-body\">\n  <div class=\"csl-entry\">John Doe。</div>\n  <div class=\"csl-entry\">——，Ziggy Zither等點校。</div>\n  <div class=\"csl-entry\">田中太郎, Yossarian Yoda, 等翻譯員。</div>\n</div>",
     "tags": false,
     "version": "1.0"
 }


### PR DESCRIPTION
The `author` label is removed in the result and I've tested it with `citeproc-js`. This is because of the removal of `author` terms in zh-TW locale in <https://github.com/citation-style-language/locales/pull/319>.

I also suggest updating of the `locale` and `fixtures/std` submodules of <https://github.com/Juris-M/citeproc-js>.