### PR TITLE
Another BC/AD test update for locale change to include leading space

### DIFF
--- a/processor-tests/humans/date_NegativeDateSortViaMacro.txt
+++ b/processor-tests/humans/date_NegativeDateSortViaMacro.txt
@@ -9,12 +9,12 @@ bibliographies, they are always placed at the end of the sort
 (whether ascending or descending).
 
 >>===== RESULT =====>>
-100BC-7-13, 44BC-3-15, 54AD-10-13, 68AD-6-11
+100 BC-7-13, 44 BC-3-15, 54 AD-10-13, 68 AD-6-11
 <<===== RESULT =====<<
 
 
 >>===== CSL =====>>
-<style 
+<style
       xmlns="http://purl.org/net/xbiblio/csl"
       class="note"
       version="1.0">
@@ -107,4 +107,3 @@ bibliographies, they are always placed at the end of the sort
 >>===== VERSION =====>>
 1.0
 <<===== VERSION =====<<
-


### PR DESCRIPTION
I am slowly working through tests I hadn’t already covered in my CSL project. This is another affected by https://github.com/citation-style-language/locales/pull/350.

To my eye, dates like `44 BC-3-15` do seem a tiny bit odd, I suppose because my eye expects a contiguous `YYYY-MM-DD` format. But as @adam3smith mentioned, particular styles can opt for the spaceless format.