### PR TITLE
Additional updates for locale changes

### DIFF
--- a/processor-tests/humans/bugreports_SortedIeeeItalicsFail.txt
+++ b/processor-tests/humans/bugreports_SortedIeeeItalicsFail.txt
@@ -7,13 +7,13 @@ bibliography
 >>===== RESULT =====>>
 <div class="csl-bib-body">
   <div class="csl-entry">
-    <div class="csl-left-margin">[1]</div><div class="csl-right-inline"> J. Doe, “His Anonymous Article,” <i>Journal of Obscurity</i>, vol. 100, p. 15, Jun. 1965.</div>
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline"> J. Doe, “His Anonymous Article,” <i>Journal of Obscurity</i>, vol. 100, p. 15, June. 1965.</div>
   </div>
   <div class="csl-entry">
-    <div class="csl-left-margin">[2]</div><div class="csl-right-inline"> G. Everhardt, “His Anonymous Article,” <i>Journal of Obscurity</i>, vol. 100, p. 15, Jun. 1965.</div>
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline"> G. Everhardt, “His Anonymous Article,” <i>Journal of Obscurity</i>, vol. 100, p. 15, June. 1965.</div>
   </div>
   <div class="csl-entry">
-    <div class="csl-left-margin">[3]</div><div class="csl-right-inline"> J. Roe, “His Anonymous Article,” <i>Journal of Obscurity</i>, vol. 100, p. 15, Jun. 1965.</div>
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline"> J. Roe, “His Anonymous Article,” <i>Journal of Obscurity</i>, vol. 100, p. 15, June. 1965.</div>
   </div>
 </div>
 <<===== RESULT =====<<
@@ -369,4 +369,3 @@ bibliography
 >>===== VERSION =====>>
 1.0
 <<===== VERSION =====<<
-

--- a/processor-tests/humans/date_NegativeDateSort.txt
+++ b/processor-tests/humans/date_NegativeDateSort.txt
@@ -9,12 +9,12 @@ bibliographies, they are always placed at the end of the sort
 (whether ascending or descending).
 
 >>===== RESULT =====>>
-100BC-7-13, 44BC-3-15, 54AD-10-13, 68AD-6-11
+100 BC-7-13, 44 BC-3-15, 54 AD-10-13, 68 AD-6-11
 <<===== RESULT =====<<
 
 
 >>===== CSL =====>>
-<style 
+<style
       xmlns="http://purl.org/net/xbiblio/csl"
       class="note"
       version="1.0">
@@ -104,4 +104,3 @@ bibliographies, they are always placed at the end of the sort
 >>===== VERSION =====>>
 1.0
 <<===== VERSION =====<<
-

--- a/processor-tests/humans/date_NegativeDateSortViaMacroOnYearMonthOnly.txt
+++ b/processor-tests/humans/date_NegativeDateSortViaMacroOnYearMonthOnly.txt
@@ -9,12 +9,12 @@ bibliographies, they are always placed at the end of the sort
 (whether ascending or descending).
 
 >>===== RESULT =====>>
-BookX (100BC-7-14), BookY (100BC-7-13), BookA (68AD-3-16), BookB (68AD-3-15)
+BookX (100 BC-7-14), BookY (100 BC-7-13), BookA (68 AD-3-16), BookB (68 AD-3-15)
 <<===== RESULT =====<<
 
 
 >>===== CSL =====>>
-<style 
+<style
       xmlns="http://purl.org/net/xbiblio/csl"
       class="note"
       version="1.0">
@@ -117,4 +117,3 @@ BookX (100BC-7-14), BookY (100BC-7-13), BookA (68AD-3-16), BookB (68AD-3-15)
 >>===== VERSION =====>>
 1.0
 <<===== VERSION =====<<
-

--- a/processor-tests/humans/date_VariousInvalidDates.txt
+++ b/processor-tests/humans/date_VariousInvalidDates.txt
@@ -3,6 +3,25 @@ citation
 <<===== MODE =====<<
 
 
+>>==== DESCRIPTION ====>>
+This depends on correct handling of seasons expressed in month parts per the
+discussion at
+https://discourse.citationstyles.org/t/edtf-and-date-representation/1663
+
+
+Additionally, it depends on further, special handling for month values 17 and
+18 per the code comment at
+
+https://github.com/Juris-M/citeproc-js/blob/master/src/node_datepart.js#L249
+
+which describes seasons derived from months "with a value of 13, 14, 15, 16,
+or (to allow correct ranging with Down Under dates) 17 or 18."
+
+This test is also described in
+https://github.com/zotero/citeproc-rs/blob/master/crates/citeproc/tests/data/snapshot.txt#L60
+
+<<==== DESCRIPTION ====<<
+
 
 >>===== RESULT =====>>
 Date: (); Date: (Spring); Date: (Spring); Date: (); Date: (Winter)
@@ -10,7 +29,7 @@ Date: (); Date: (Spring); Date: (Spring); Date: (); Date: (Winter)
 
 
 >>===== CSL =====>>
-<style 
+<style
       xmlns="http://purl.org/net/xbiblio/csl"
       class="note"
       version="1.0">
@@ -106,4 +125,3 @@ Date: (); Date: (Spring); Date: (Spring); Date: (); Date: (Winter)
 >>===== VERSION =====>>
 1.0
 <<===== VERSION =====<<
-

--- a/processor-tests/humans/date_VariousInvalidDates.txt
+++ b/processor-tests/humans/date_VariousInvalidDates.txt
@@ -4,10 +4,10 @@ citation
 
 
 >>==== DESCRIPTION ====>>
+
 This depends on correct handling of seasons expressed in month parts per the
 discussion at
 https://discourse.citationstyles.org/t/edtf-and-date-representation/1663
-
 
 Additionally, it depends on further, special handling for month values 17 and
 18 per the code comment at

--- a/processor-tests/humans/decorations_Baseline.txt
+++ b/processor-tests/humans/decorations_Baseline.txt
@@ -6,13 +6,13 @@ bibliography
 
 >>== RESULT ==>>
 <div class="csl-bib-body">
-  <div class="csl-entry"><sup>Little, Stuart, <span style="baseline">My Short Narrative</span> (1990)</sup></div>
+  <div class="csl-entry"><sup>Little, Stuart, <span class="baseline">My Short Narrative</span> (1990)</sup></div>
 </div>
 <<== RESULT ==<<
 
 
 >>===== CSL =====>>
-<style 
+<style
       xmlns="http://purl.org/net/xbiblio/csl"
       class="note"
       version="1.0">
@@ -70,4 +70,3 @@ bibliography
 >>===== VERSION =====>>
 1.0
 <<===== VERSION =====<<
-

--- a/processor-tests/humans/disambiguate_SkipAccessedYearSuffix.txt
+++ b/processor-tests/humans/disambiguate_SkipAccessedYearSuffix.txt
@@ -13,7 +13,7 @@ bibliography
 
 
 >>===== CSL =====>>
-<style 
+<style
       xmlns="http://purl.org/net/xbiblio/csl"
       class="note"
       version="1.0">
@@ -29,8 +29,8 @@ bibliography
     </names>
   </macro>
   <macro name="publisher">
-    <text variable="publisher" suffix=", "/>       
-    <text variable="publisher-place" suffix=", "/>     
+    <text variable="publisher" suffix=", "/>
+    <text variable="publisher-place" suffix=", "/>
     <text macro="date"/>
   </macro>
   <macro name="date">
@@ -104,7 +104,8 @@ bibliography
   <!--   formatting citation      -->
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <layout>
-      <text value="BOGUS"/>
+      <text macro="title" suffix=". "/>
+      <text macro="publisher"/>
     </layout>
   </citation>
   <!--   formatting bibliography      -->
@@ -193,4 +194,3 @@ bibliography
 >>===== VERSION =====>>
 1.0
 <<===== VERSION =====<<
-

--- a/processor-tests/humans/magic_SubsequentAuthorSubstituteNotFooled.txt
+++ b/processor-tests/humans/magic_SubsequentAuthorSubstituteNotFooled.txt
@@ -6,7 +6,7 @@ bibliography
 
 >>===== RESULT =====>>
 <div class="csl-bib-body">
-  <div class="csl-entry">Silverstein, Theodore, tran. “Sir Gawain and the Green Knight.” Chicago: University of Chicago Press, 1974.</div>
+  <div class="csl-entry">Silverstein, Theodore, trans. “Sir Gawain and the Green Knight.” Chicago: University of Chicago Press, 1974.</div>
   <div class="csl-entry">Soltes, Ori A., ed. “Georgia: Art and Civilization through the Ages.” London: Philip Wilson, 1999.</div>
   <div class="csl-entry">“The Chicago Manual of Style.” Chicago: University of Chicago Press, 1993.</div>
 </div>
@@ -433,7 +433,7 @@ Chicago Author-Date.
     <text suffix=" " variable="title" />
     <text variable="genre" />
   </macro>
-  <citation 
+  <citation
          disambiguate-add-names="true"
          et-al-min="4"
          et-al-subsequent-min="4"
@@ -460,7 +460,7 @@ Chicago Author-Date.
       </choose>
     </layout>
   </citation>
-  <bibliography 
+  <bibliography
          entry-spacing="0"
          et-al-min="11"
          et-al-use-first="7"
@@ -557,4 +557,3 @@ Chicago Author-Date.
 >>===== VERSION =====>>
 1.0
 <<===== VERSION =====<<
-

--- a/processor-tests/humans/sort_OmittedBibRefMixedNumericStyle.txt
+++ b/processor-tests/humans/sort_OmittedBibRefMixedNumericStyle.txt
@@ -2,6 +2,21 @@
 bibliography
 <<==== MODE ====<<
 
+>>==== DESCRIPTION ====>>
+
+This depends on two processor implementation details:
+
+1. outputting an exact error message when a style produces no output for a
+   reference, and
+
+2. temporarily ignoring <choose/> conditions to find and render
+   <text variable="citation-number"/>, if defined, for the omitted reference.
+
+For an implementation example, see
+https://github.com/zotero/citeproc-rs/blob/master/crates/proc/src/db.rs#L1414
+
+<<==== DESCRIPTION ====<<
+
 >>==== RESULT ====>>
 <div class="csl-bib-body">
   <div class="csl-entry">1. Anderson, Book One</div>
@@ -27,7 +42,7 @@ bibliography
 <<==== CITATION-ITEMS ====<<
 
 >>==== CSL ====>>
-<style 
+<style
       xmlns="http://purl.org/net/xbiblio/csl"
       class="note"
       version="1.0">
@@ -120,4 +135,3 @@ bibliography
 >>===== VERSION =====>>
 1.0
 <<===== VERSION =====<<
-

--- a/processor-tests/humans/sort_OmittedBibRefMixedNumericStyle.txt
+++ b/processor-tests/humans/sort_OmittedBibRefMixedNumericStyle.txt
@@ -4,16 +4,22 @@ bibliography
 
 >>==== DESCRIPTION ====>>
 
-This depends on two processor implementation details:
+This depends on
 
-1. outputting an exact error message when a style produces no output for a
-   reference, and
+1. identifying when citation-number is used,
 
-2. temporarily ignoring <choose/> conditions to find and render
-   <text variable="citation-number"/>, if defined, for the omitted reference.
+2. outputting a particular error message in place of a reference that produces
+   no output, to maintain citation-number sequencing, and
+
+2. rendering the <bibliography/> <text variable="citation-number"/>
+   for the omitted reference, ignoring the conditions that omitted the
+   reference.
 
 For an implementation example, see
 https://github.com/zotero/citeproc-rs/blob/master/crates/proc/src/db.rs#L1414
+
+Compare to the sort_OmittedBibRefNonNumericStyle test which has a similar
+non-rendering reference but no citation-numbers.
 
 <<==== DESCRIPTION ====<<
 


### PR DESCRIPTION
Unless otherwise noted, these are minimally updated to match locale changes in https://github.com/citation-style-language/locales/pull/343

## decorations_Baseline

Changed
```html
<span style="baseline"> <!— old value —>
<span class="baseline"> <!— new value —>
```
in the expected output because
- HTML *style* attributes must have the form `style="property: value"` whereas *class* attributes are simple names that may not include `:` (and other characters)
- which aligns with the [documentation](https://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html#html-like-formatting-tags) which lists *class* and *style* attributes following these basic HTML rules

My guess is that this was just a typo in the test. I understand this is meant only to be HTML-*like* but I’d vote against needlessly breaking basic HTML parsing.

## disambiguate_SkipAccessedYearSuffix

No changes were made to the inputs or outputs of this *bibliography* test but the `<layout/>` of the citation was changed from
```xml
<text value="BOGUS"/>
```
to
```xml
<text macro="title" suffix=". "/>
<text macro="publisher"/>
```
so that a year exists in the citation to be affected by `disambiguate-add-year-suffix=“true”`, matching the expected output.

Unless I’ve overlooked something in the specification, it’s reasonable to only apply a year suffix when a year will exist in the rendered citation. Apparently the `citeproc-?s` processors choose otherwise but I don’t see that’s required.

And so I’ve updated this test in a way that will still pass for `citeproc-?s` but will also pass for processors with logic like mine.

## Descriptions Added

To these I added descriptions but made no other change
- date_VariousInvalidDates 
- sort_OmittedBibRefMixedNumericStyle