### PR TITLE
Update tests for repeated author substitution

### DIFF
--- a/processor-tests/humans/fullstyles_ChicagoAuthorDateSimple.txt
+++ b/processor-tests/humans/fullstyles_ChicagoAuthorDateSimple.txt
@@ -11,7 +11,7 @@ bibliography
   <div class="csl-entry">Doe, John, and Jane Roe. 1991. <i>Book B</i>.</div>
   <div class="csl-entry">Doe, John, Jane Roe, and Alvin Asthma. 1992. <i>Book C</i>.</div>
   <div class="csl-entry">Doe, John, Jane Roe, Alvin Asthma, Bob Bronchitis, Chris Cold, Don Dropsy, Ernie Enteritis, et al. 1993. <i>Book D</i>.</div>
-  <div class="csl-entry">---. 1994. <i>Book E</i>.</div>
+  <div class="csl-entry">Doe, John, Jane Roe, Alvin Asthma, Bob Bronchitis, Chris Cold, Don Dropsy, Ernie Enteritis, et al. 1994. <i>Book E</i>.</div>
 </div>
 <<===== RESULT =====<<
 

--- a/processor-tests/humans/name_SubsequentAuthorSubstituteEtAl.txt
+++ b/processor-tests/humans/name_SubsequentAuthorSubstituteEtAl.txt
@@ -1,0 +1,84 @@
+>>===== MODE =====>>
+bibliography
+<<===== MODE =====<<
+
+
+>>===== DESCRIPTION =====>>
+<https://tex.stackexchange.com/q/756102/82731>
+<<===== DESCRIPTION =====<<
+
+
+>>===== RESULT =====>>
+<div class="csl-bib-body">
+  <div class="csl-entry">Ulrich Luz, Karl Suso Frank, et al.</div>
+  <div class="csl-entry">Ulrich Luz, Karl Suso Frank</div>
+</div>
+<<===== RESULT =====<<
+
+
+>>===== CSL =====>>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2026-03-23T15:05:15+00:00</updated>
+  </info>
+  <citation>
+    <layout>
+      <text value="dummy"/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="3" et-al-use-first="2" subsequent-author-substitute="---" subsequent-author-substitute-rule="complete-all">
+    <layout>
+      <names variable="author"/>
+    </layout>
+  </bibliography>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "author": [
+            {
+                "family": "Luz",
+                "given": "Ulrich"
+            },
+            {
+                "family": "Frank",
+                "given": "Karl Suso"
+            },
+            {
+                "family": "Riches",
+                "given": "John K."
+            },
+            {
+                "family": "Klimkeit",
+                "given": "Hans-Joachim"
+            }
+        ],
+        "id": "LuzEtAl_NachfolgeTRE",
+        "type": "entry-encyclopedia"
+    },
+    {
+        "author": [
+            {
+                "family": "Luz",
+                "given": "Ulrich"
+            },
+            {
+                "family": "Frank",
+                "given": "Karl Suso"
+            }
+        ],
+        "id": "Luz_TRE23Nachfolge",
+        "type": "entry-encyclopedia"
+    }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<

--- a/processor-tests/machines/fullstyles_ChicagoAuthorDateSimple.json
+++ b/processor-tests/machines/fullstyles_ChicagoAuthorDateSimple.json
@@ -196,7 +196,7 @@
         }
     ],
     "mode": "bibliography",
-    "result": "<div class=\"csl-bib-body\">\n  <div class=\"csl-entry\">Doe, John. 1990. <i>Book A</i>. Brobdingnag: Zardoz Press.</div>\n  <div class=\"csl-entry\">Doe, John, and Jane Roe. 1991. <i>Book B</i>.</div>\n  <div class=\"csl-entry\">Doe, John, Jane Roe, and Alvin Asthma. 1992. <i>Book C</i>.</div>\n  <div class=\"csl-entry\">Doe, John, Jane Roe, Alvin Asthma, Bob Bronchitis, Chris Cold, Don Dropsy, Ernie Enteritis, et al. 1993. <i>Book D</i>.</div>\n  <div class=\"csl-entry\">---. 1994. <i>Book E</i>.</div>\n</div>",
+    "result": "<div class=\"csl-bib-body\">\n  <div class=\"csl-entry\">Doe, John. 1990. <i>Book A</i>. Brobdingnag: Zardoz Press.</div>\n  <div class=\"csl-entry\">Doe, John, and Jane Roe. 1991. <i>Book B</i>.</div>\n  <div class=\"csl-entry\">Doe, John, Jane Roe, and Alvin Asthma. 1992. <i>Book C</i>.</div>\n  <div class=\"csl-entry\">Doe, John, Jane Roe, Alvin Asthma, Bob Bronchitis, Chris Cold, Don Dropsy, Ernie Enteritis, et al. 1993. <i>Book D</i>.</div>\n  <div class=\"csl-entry\">Doe, John, Jane Roe, Alvin Asthma, Bob Bronchitis, Chris Cold, Don Dropsy, Ernie Enteritis, et al. 1994. <i>Book E</i>.</div>\n</div>",
     "tags": false,
     "version": "1.0"
 }

--- a/processor-tests/machines/name_SubsequentAuthorSubstituteEtAl.json
+++ b/processor-tests/machines/name_SubsequentAuthorSubstituteEtAl.json
@@ -1,0 +1,50 @@
+{
+    "abbreviations": false,
+    "bibentries": false,
+    "bibsection": false,
+    "citation_items": false,
+    "citations": false,
+    "csl": "<style xmlns=\"http://purl.org/net/xbiblio/csl\" class=\"note\" version=\"1.0\">\n  <info>\n    <id />\n    <title />\n    <updated>2026-03-23T15:05:15+00:00</updated>\n  </info>\n  <citation>\n    <layout>\n      <text value=\"dummy\"/>\n    </layout>\n  </citation>\n  <bibliography et-al-min=\"3\" et-al-use-first=\"2\" subsequent-author-substitute=\"---\" subsequent-author-substitute-rule=\"complete-all\">\n    <layout>\n      <names variable=\"author\"/>\n    </layout>\n  </bibliography>\n</style>",
+    "input": [
+        {
+            "author": [
+                {
+                    "family": "Luz",
+                    "given": "Ulrich"
+                },
+                {
+                    "family": "Frank",
+                    "given": "Karl Suso"
+                },
+                {
+                    "family": "Riches",
+                    "given": "John K."
+                },
+                {
+                    "family": "Klimkeit",
+                    "given": "Hans-Joachim"
+                }
+            ],
+            "id": "LuzEtAl_NachfolgeTRE",
+            "type": "entry-encyclopedia"
+        },
+        {
+            "author": [
+                {
+                    "family": "Luz",
+                    "given": "Ulrich"
+                },
+                {
+                    "family": "Frank",
+                    "given": "Karl Suso"
+                }
+            ],
+            "id": "Luz_TRE23Nachfolge",
+            "type": "entry-encyclopedia"
+        }
+    ],
+    "mode": "bibliography",
+    "result": "<div class=\"csl-bib-body\">\n  <div class=\"csl-entry\">Ulrich Luz, Karl Suso Frank, et al.</div>\n  <div class=\"csl-entry\">Ulrich Luz, Karl Suso Frank</div>\n</div>",
+    "tags": false,
+    "version": "1.0"
+}


### PR DESCRIPTION
The authors in `ITEM-4` and `ITEM-5` of [`fullstyles_ChicagoAuthorDateSimple.txt`](https://github.com/citation-style-language/test-suite/blob/5e2c0ed89b3d728376592ecac8eb21e39ced3f77/processor-tests/humans/fullstyles_ChicagoAuthorDateSimple.txt) are abbreviated to the same `et-al` form but they are not completely the same. The `subsequent-author-substitute` should not be applied in this case.

https://github.com/citation-style-language/test-suite/blob/5e2c0ed89b3d728376592ecac8eb21e39ced3f77/processor-tests/humans/fullstyles_ChicagoAuthorDateSimple.txt#L505-L509

https://github.com/citation-style-language/test-suite/blob/5e2c0ed89b3d728376592ecac8eb21e39ced3f77/processor-tests/humans/fullstyles_ChicagoAuthorDateSimple.txt#L563-L571

The test in issue <https://github.com/Juris-M/citeproc-js/issues/274> is also added.

I've prepared a patch to citeproc-js after this PR is merged.