### PR TITLE
Add test case for chicago-15 for page ranges with numbers >10000

### DIFF
--- a/processor-tests/humans/page_Chicago.txt
+++ b/processor-tests/humans/page_Chicago.txt
@@ -22,6 +22,7 @@ Example O, at 11564–78
 Example P, at 13792–803
 Example Q, at 1496–1504
 Example R, at 2787–2816
+Example S, at 11153–2359
 <<===== RESULT =====<<
 
 
@@ -115,6 +116,11 @@ Example R, at 2787–2816
     [
         {
             "id": "ITEM-18"
+        }
+    ],
+    [
+        {
+            "id": "ITEM-19"
         }
     ]
 ]
@@ -252,9 +258,15 @@ Example R, at 2787–2816
         "type": "book"
     }, 
     {
-        "id": "ITEM-18", 
-        "page": "2787-816", 
-        "title": "Example R", 
+        "id": "ITEM-18",
+        "page": "2787-816",
+        "title": "Example R",
+        "type": "book"
+    },
+    {
+        "id": "ITEM-19",
+        "page": "11153-12359",
+        "title": "Example S",
         "type": "book"
     }
 ]


### PR DESCRIPTION
Test that 11153-12359 is abbreviated to 11153-2359, not 11153-359.

Fixed for citeproc-js in https://github.com/Juris-M/citeproc-js/pull/275